### PR TITLE
Add symfony/phpunit-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "phpstan/phpstan-symfony": "^0.12.33",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.15.1",
+        "symfony/phpunit-bridge": "^5.0",
         "twig/twig": "^3.0",
         "vimeo/psalm": "^4.7"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
         <server name="KERNEL_CLASS" value="Nusje2000\CAH\Kernel"/>
         <server name="PANTHER_NO_HEADLESS" value="1"/>
         <env name="COLUMNS" value="120"></env>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1"></env>
     </php>
     <testsuites>
         <testsuite name="Project Test Suite">


### PR DESCRIPTION
Fixes #46 

I've disabled the deprecation logging by default, so it can be enabled when it's needed to check on deprecations.