### PR TITLE
Feature/add description to feature toggles

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -47,7 +47,7 @@ nusje2000_feature_toggle:
             feature_2: true
             feature_3: false
             feature_4:
-                value: true
+                enabled: true
                 description: 'This is a feature with a description!'
         access_control:
             - { path: '^/feature-protected', ips: [ 127.0.0.1 ], port: 8080, features: { some_feature: true } }

--- a/USAGE.md
+++ b/USAGE.md
@@ -46,6 +46,9 @@ nusje2000_feature_toggle:
             feature_1: true
             feature_2: true
             feature_3: false
+            feature_4:
+                value: true
+                description: 'This is a feature with a description!'
         access_control:
             - { path: '^/feature-protected', ips: [ 127.0.0.1 ], port: 8080, features: { some_feature: true } }
             - { path: '^/feature-protected', ips: [ 127.0.0.1 ], features: { some_feature: true } }

--- a/host_api.md
+++ b/host_api.md
@@ -109,12 +109,15 @@ Defines a new feature toggle with a default value. Will return a 201 status if t
 
 ### PATCH /{environment}/{name}
 
-Updates an existing feature toggle with a new value. Will return a 200 status if the update was succesfull.
+Updates an existing feature toggle with a new value and/or description.
+The state and description will only be updated if the keys are present in the payload.
+Will return a 200 status if the update was succesfull.
 
 ```json5
 // Request
 {
-    "enabled": true // boolean
+    "enabled": true, // boolean
+    "description": "FooBar" // string|null
 }
 ```
 

--- a/src/Controller/Host/Feature/CreateController.php
+++ b/src/Controller/Host/Feature/CreateController.php
@@ -59,6 +59,12 @@ final class CreateController
             throw new BadRequestHttpException('Missing/Invalid feature state, please provide a boolean value for the "enabled" key.');
         }
 
-        return new SimpleFeature($name, State::fromBoolean($enabled));
+        /** @var mixed $description */
+        $description = $json['description'] ?? null;
+        if (!is_null($description) && !is_string($description)) {
+            throw new BadRequestHttpException('Invalid feature description, please provide a string or null value for the "description" key, or exclude the value from the json.');
+        }
+
+        return new SimpleFeature($name, State::fromBoolean($enabled), $description);
     }
 }

--- a/src/Controller/Host/Feature/UpdateController.php
+++ b/src/Controller/Host/Feature/UpdateController.php
@@ -34,7 +34,8 @@ final class UpdateController
         $feature = $this->repository->find($environment, $name);
 
         $json = $this->requestParser->json($request);
-        $this->updateFeature($feature, $json);
+        $this->updateFeatureState($feature, $json);
+        $this->updateFeatureDescription($feature, $json);
         $this->repository->update($environment, $feature);
 
         return new Response(sprintf('Updated feature named "%s" in environment "%s".', $name, $environment));
@@ -43,7 +44,7 @@ final class UpdateController
     /**
      * @param array<mixed> $json
      */
-    private function updateFeature(Feature $feature, array $json): void
+    private function updateFeatureState(Feature $feature, array $json): void
     {
         $enabled = $json['enabled'] ?? null;
         if (!is_bool($enabled)) {
@@ -57,5 +58,20 @@ final class UpdateController
         }
 
         $feature->disable();
+    }
+
+    /**
+     * @param array<mixed> $json
+     */
+    private function updateFeatureDescription(Feature $feature, array $json): void
+    {
+        $description = $json['description'] ?? null;
+        if (!is_null($description) && !is_string($description)) {
+            throw new BadRequestHttpException('Invalid feature description, please provide a string or null value for the "description" key, or exclude the value from the json.');
+        }
+
+        if ($feature->description() !== $description) {
+            $feature->setDescription($description);
+        }
     }
 }

--- a/src/Controller/Host/Feature/UpdateController.php
+++ b/src/Controller/Host/Feature/UpdateController.php
@@ -46,9 +46,13 @@ final class UpdateController
      */
     private function updateFeatureState(Feature $feature, array $json): void
     {
-        $enabled = $json['enabled'] ?? null;
+        if (!array_key_exists('enabled', $json)) {
+            return;
+        }
+
+        $enabled = $json['enabled'];
         if (!is_bool($enabled)) {
-            throw new BadRequestHttpException('Missing/Invalid feature state, please provide a boolean value for the "enabled" key.');
+            throw new BadRequestHttpException('Invalid feature state, please provide a boolean value for the "enabled" key.');
         }
 
         if ($enabled) {
@@ -65,7 +69,11 @@ final class UpdateController
      */
     private function updateFeatureDescription(Feature $feature, array $json): void
     {
-        $description = $json['description'] ?? null;
+        if (!array_key_exists('description', $json)) {
+            return;
+        }
+
+        $description = $json['description'];
         if (!is_null($description) && !is_string($description)) {
             throw new BadRequestHttpException('Invalid feature description, please provide a string or null value for the "description" key, or exclude the value from the json.');
         }

--- a/src/Controller/Host/Feature/ViewController.php
+++ b/src/Controller/Host/Feature/ViewController.php
@@ -27,6 +27,7 @@ final class ViewController
         $response = new JsonResponse([
             'name' => $feature->name(),
             'enabled' => $feature->state()->isEnabled(),
+            'description' => $feature->description(),
         ]);
 
         $response->setCache([

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -49,9 +49,9 @@ final class Configuration implements ConfigurationInterface
                 function ($v) {
                     return is_bool($v);
                 })->then(function (bool $v) {
-                return ['value' => $v];
+                return ['enabled' => $v];
             });
-        $features->children()->booleanNode('value')->isRequired();
+        $features->children()->booleanNode('enabled')->isRequired();
         $features->children()->scalarNode('description')->defaultNull();
 
         $accessControl = $environment->arrayNode('access_control')->cannotBeOverwritten()->arrayPrototype()->children();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -43,7 +43,16 @@ final class Configuration implements ConfigurationInterface
         $environment = $root->children()->arrayNode('environment')->canBeEnabled()->children();
         $environment->scalarNode('name')->isRequired();
         $environment->arrayNode('hosts')->requiresAtLeastOneElement()->isRequired()->scalarPrototype();
-        $environment->arrayNode('features')->useAttributeAsKey('name')->booleanPrototype();
+        $features = $environment->arrayNode('features')->useAttributeAsKey('name')->arrayPrototype();
+        $features->beforeNormalization()
+            ->ifTrue(function ($v) {
+                return is_bool($v);
+            })->then(function (bool $v) {
+                return ['value' => $v];
+            });
+        $features->children()
+            ->booleanNode('value')->isRequired()->end()
+            ->scalarNode('description')->defaultNull();
 
         $accessControl = $environment->arrayNode('access_control')->cannotBeOverwritten()->arrayPrototype()->children();
         $accessControl->scalarNode('path')->defaultNull();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -45,14 +45,14 @@ final class Configuration implements ConfigurationInterface
         $environment->arrayNode('hosts')->requiresAtLeastOneElement()->isRequired()->scalarPrototype();
         $features = $environment->arrayNode('features')->useAttributeAsKey('name')->arrayPrototype();
         $features->beforeNormalization()
-            ->ifTrue(function ($v) {
-                return is_bool($v);
-            })->then(function (bool $v) {
+            ->ifTrue(/** @param mixed $v */
+                function ($v) {
+                    return is_bool($v);
+                })->then(function (bool $v) {
                 return ['value' => $v];
             });
-        $features->children()
-            ->booleanNode('value')->isRequired()->end()
-            ->scalarNode('description')->defaultNull();
+        $features->children()->booleanNode('value')->isRequired();
+        $features->children()->scalarNode('description')->defaultNull();
 
         $accessControl = $environment->arrayNode('access_control')->cannotBeOverwritten()->arrayPrototype()->children();
         $accessControl->scalarNode('path')->defaultNull();

--- a/src/DependencyInjection/Nusje2000FeatureToggleExtension.php
+++ b/src/DependencyInjection/Nusje2000FeatureToggleExtension.php
@@ -59,7 +59,10 @@ final class Nusje2000FeatureToggleExtension extends Extension
          *          enabled: bool,
          *          name: string,
          *          hosts: list<string>,
-         *          features: array<array-key, bool>,
+         *          features: array<array-key, array{
+         *              value: bool,
+         *              description: string|null
+         *          }>,
          *          access_control: list<array{
          *              path: string|null,
          *              host: string|null,
@@ -105,7 +108,10 @@ final class Nusje2000FeatureToggleExtension extends Extension
      *     enabled: bool,
      *     name: string,
      *     hosts: list<string>,
-     *     features: array<array-key, bool>,
+     *     features: array<array-key, array{
+     *          value: bool,
+     *          description: string|null
+     *     }>,
      *     access_control: list<array{
      *         path: string|null,
      *         host: string|null,
@@ -136,13 +142,14 @@ final class Nusje2000FeatureToggleExtension extends Extension
             }
         }
 
-        foreach ($config['features'] as $name => $enabled) {
+        foreach ($config['features'] as $name => $feature) {
             $container->getDefinition('nusje2000_feature_toggle.default_environment')->addMethodCall('addFeature', [
                 new Definition(SimpleFeature::class, [
                     (string) $name,
                     new Definition(State::class, [
-                        State::fromBoolean($enabled)->getValue(),
+                        State::fromBoolean($feature['value'])->getValue(),
                     ]),
+                    $feature['description'],
                 ]),
             ]);
         }

--- a/src/DependencyInjection/Nusje2000FeatureToggleExtension.php
+++ b/src/DependencyInjection/Nusje2000FeatureToggleExtension.php
@@ -60,7 +60,7 @@ final class Nusje2000FeatureToggleExtension extends Extension
          *          name: string,
          *          hosts: list<string>,
          *          features: array<array-key, array{
-         *              value: bool,
+         *              enabled: bool,
          *              description: string|null
          *          }>,
          *          access_control: list<array{
@@ -109,7 +109,7 @@ final class Nusje2000FeatureToggleExtension extends Extension
      *     name: string,
      *     hosts: list<string>,
      *     features: array<array-key, array{
-     *          value: bool,
+     *          enabled: bool,
      *          description: string|null
      *     }>,
      *     access_control: list<array{
@@ -147,7 +147,7 @@ final class Nusje2000FeatureToggleExtension extends Extension
                 new Definition(SimpleFeature::class, [
                     (string) $name,
                     new Definition(State::class, [
-                        State::fromBoolean($feature['value'])->getValue(),
+                        State::fromBoolean($feature['enabled'])->getValue(),
                     ]),
                     $feature['description'],
                 ]),

--- a/src/Feature/Feature.php
+++ b/src/Feature/Feature.php
@@ -13,4 +13,6 @@ interface Feature
     public function enable(): void;
 
     public function disable(): void;
+
+    public function description(): ?string;
 }

--- a/src/Feature/Feature.php
+++ b/src/Feature/Feature.php
@@ -15,4 +15,6 @@ interface Feature
     public function disable(): void;
 
     public function description(): ?string;
+
+    public function setDescription(?string $description): void;
 }

--- a/src/Feature/SimpleFeature.php
+++ b/src/Feature/SimpleFeature.php
@@ -52,4 +52,9 @@ final class SimpleFeature implements Feature
     {
         return $this->description;
     }
+
+    public function setDescription(?string $description): void
+    {
+        $this->description = $description;
+    }
 }

--- a/src/Feature/SimpleFeature.php
+++ b/src/Feature/SimpleFeature.php
@@ -16,10 +16,16 @@ final class SimpleFeature implements Feature
      */
     private $state;
 
-    public function __construct(string $name, State $state)
+    /**
+     * @var string|null
+     */
+    private $description;
+
+    public function __construct(string $name, State $state, ?string $description = null)
     {
         $this->name = $name;
         $this->state = $state;
+        $this->description = $description;
     }
 
     public function name(): string
@@ -40,5 +46,10 @@ final class SimpleFeature implements Feature
     public function disable(): void
     {
         $this->state = State::DISABLED();
+    }
+
+    public function description(): ?string
+    {
+        return $this->description;
     }
 }

--- a/src/Http/Response/FeatureMapper.php
+++ b/src/Http/Response/FeatureMapper.php
@@ -26,6 +26,11 @@ final class FeatureMapper
             throw InvalidResponse::invalidKeyType('enabled', 'bool', $enabled);
         }
 
-        return new SimpleFeature($name, State::fromBoolean($enabled));
+        $description = $json['description'] ?? null;
+        if (!is_null($description) && !is_string($description)) {
+            throw InvalidResponse::invalidKeyType('description', 'string|null', $description);
+        }
+
+        return new SimpleFeature($name, State::fromBoolean($enabled), $description);
     }
 }

--- a/tests/Unit/Controller/Host/Feature/CreateControllerTest.php
+++ b/tests/Unit/Controller/Host/Feature/CreateControllerTest.php
@@ -31,6 +31,22 @@ final class CreateControllerTest extends TestCase
         $controller($request, 'environment');
     }
 
+    public function testInvokeWithDescription(): void
+    {
+        $repository = $this->createMock(FeatureRepository::class);
+        $repository->expects(self::once())->method('add')->with(
+            'environment',
+            new SimpleFeature('feature_1', State::ENABLED(), 'fooBar')
+        );
+
+        $controller = new CreateController(new RequestParser(), $repository);
+
+        $request = $this->createStub(Request::class);
+        $request->method('getContent')->willReturn('{"name": "feature_1", "enabled": true, "description": "fooBar"}');
+
+        $controller($request, 'environment');
+    }
+
     public function testInvokeWithMissingName(): void
     {
         $repository = $this->createMock(FeatureRepository::class);
@@ -57,6 +73,21 @@ final class CreateControllerTest extends TestCase
 
         $this->expectException(BadRequestHttpException::class);
         $this->expectExceptionMessage('Missing/Invalid feature state, please provide a boolean value for the "enabled" key.');
+
+        $controller($request, 'environment');
+    }
+
+    public function testInvokeWithInvalidDescription(): void
+    {
+        $repository = $this->createMock(FeatureRepository::class);
+
+        $controller = new CreateController(new RequestParser(), $repository);
+
+        $request = $this->createStub(Request::class);
+        $request->method('getContent')->willReturn('{"name": "feature_1", "enabled": false, "description": []}');
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('Invalid feature description, please provide a string or null value for the "description" key, or exclude the value from the json.');
 
         $controller($request, 'environment');
     }

--- a/tests/Unit/Controller/Host/Feature/UpdateControllerTest.php
+++ b/tests/Unit/Controller/Host/Feature/UpdateControllerTest.php
@@ -63,4 +63,21 @@ final class UpdateControllerTest extends TestCase
 
         $controller($request, 'environment', 'feature');
     }
+
+    public function testInvokeWithChangedDescription(): void
+    {
+        $repository = $this->createMock(FeatureRepository::class);
+        $repository->method('find')->willReturn(new SimpleFeature('feature_1', State::DISABLED()));
+        $repository->expects(self::once())->method('update')->with(
+            'environment',
+            new SimpleFeature('feature_1', State::ENABLED(), 'fooBar')
+        );
+
+        $controller = new UpdateController(new RequestParser(), $repository);
+
+        $request = $this->createStub(Request::class);
+        $request->method('getContent')->willReturn('{"enabled": true, "description": "fooBar"}');
+
+        $controller($request, 'environment', 'feature');
+    }
 }

--- a/tests/Unit/Controller/Host/Feature/UpdateControllerTest.php
+++ b/tests/Unit/Controller/Host/Feature/UpdateControllerTest.php
@@ -80,4 +80,19 @@ final class UpdateControllerTest extends TestCase
 
         $controller($request, 'environment', 'feature');
     }
+
+    public function testInvokeWithInvalidDescription(): void
+    {
+        $repository = $this->createMock(FeatureRepository::class);
+
+        $controller = new UpdateController(new RequestParser(), $repository);
+
+        $request = $this->createStub(Request::class);
+        $request->method('getContent')->willReturn('{"enabled": true, "description": []}');
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('Invalid feature description, please provide a string or null value for the "description" key, or exclude the value from the json.');
+
+        $controller($request, 'environment', 'feature');
+    }
 }

--- a/tests/Unit/Controller/Host/Feature/ViewControllerTest.php
+++ b/tests/Unit/Controller/Host/Feature/ViewControllerTest.php
@@ -27,6 +27,28 @@ final class ViewControllerTest extends TestCase
             [
                 'name' => 'feature_1',
                 'enabled' => true,
+                'description' => null,
+            ],
+            json_decode($content, true)
+        );
+    }
+
+    public function testInvokeWithDescription(): void
+    {
+        $repository = $this->createMock(FeatureRepository::class);
+        $repository->method('find')->willReturn(new SimpleFeature('feature_1', State::ENABLED(), 'fooBar'));
+
+        $controller = new ViewController($repository);
+
+        $response = $controller('some_env', 'feature_1');
+
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(
+            [
+                'name' => 'feature_1',
+                'enabled' => true,
+                'description' => 'fooBar',
             ],
             json_decode($content, true)
         );

--- a/tests/Unit/DependencyInjection/Nusje2000FeatureToggleExtensionTest.php
+++ b/tests/Unit/DependencyInjection/Nusje2000FeatureToggleExtensionTest.php
@@ -135,7 +135,7 @@ final class Nusje2000FeatureToggleExtensionTest extends TestCase
                         'disabled_feature' => false,
                         'overwriten_feature' => false,
                         'descriptive_feature' => [
-                            'value' => true,
+                            'enabled' => true,
                             'description' => 'fooBar',
                         ],
                     ],
@@ -164,10 +164,10 @@ final class Nusje2000FeatureToggleExtensionTest extends TestCase
         self::assertEquals(['localhost'], $container->getParameter('nusje2000_feature_toggle.hosts'));
 
         self::assertEquals([
-            'enabled_feature' => ['value' => true, 'description' => null],
-            'disabled_feature' => ['value' => false, 'description' => null],
-            'overwriten_feature' => ['value' => true, 'description' => null],
-            'descriptive_feature' => ['value' => true, 'description' => 'fooBar'],
+            'enabled_feature' => ['enabled' => true, 'description' => null],
+            'disabled_feature' => ['enabled' => false, 'description' => null],
+            'overwriten_feature' => ['enabled' => true, 'description' => null],
+            'descriptive_feature' => ['enabled' => true, 'description' => 'fooBar'],
         ], $container->getParameter('nusje2000_feature_toggle.feature_defaults'));
 
         /** @var EnvironmentRepository $repository */

--- a/tests/Unit/DependencyInjection/Nusje2000FeatureToggleExtensionTest.php
+++ b/tests/Unit/DependencyInjection/Nusje2000FeatureToggleExtensionTest.php
@@ -134,6 +134,10 @@ final class Nusje2000FeatureToggleExtensionTest extends TestCase
                         'enabled_feature' => true,
                         'disabled_feature' => false,
                         'overwriten_feature' => false,
+                        'descriptive_feature' => [
+                            'value' => true,
+                            'description' => 'fooBar',
+                        ],
                     ],
                 ],
             ],
@@ -160,9 +164,10 @@ final class Nusje2000FeatureToggleExtensionTest extends TestCase
         self::assertEquals(['localhost'], $container->getParameter('nusje2000_feature_toggle.hosts'));
 
         self::assertEquals([
-            'enabled_feature' => true,
-            'disabled_feature' => false,
-            'overwriten_feature' => true,
+            'enabled_feature' => ['value' => true, 'description' => null],
+            'disabled_feature' => ['value' => false, 'description' => null],
+            'overwriten_feature' => ['value' => true, 'description' => null],
+            'descriptive_feature' => ['value' => true, 'description' => 'fooBar'],
         ], $container->getParameter('nusje2000_feature_toggle.feature_defaults'));
 
         /** @var EnvironmentRepository $repository */
@@ -177,6 +182,7 @@ final class Nusje2000FeatureToggleExtensionTest extends TestCase
                     new SimpleFeature('enabled_feature', State::ENABLED()),
                     new SimpleFeature('disabled_feature', State::DISABLED()),
                     new SimpleFeature('overwriten_feature', State::ENABLED()),
+                    new SimpleFeature('descriptive_feature', State::ENABLED(), 'fooBar'),
                 ]
             ),
         ], $environments);
@@ -188,6 +194,7 @@ final class Nusje2000FeatureToggleExtensionTest extends TestCase
                 new SimpleFeature('enabled_feature', State::ENABLED()),
                 new SimpleFeature('disabled_feature', State::DISABLED()),
                 new SimpleFeature('overwriten_feature', State::ENABLED()),
+                new SimpleFeature('descriptive_feature', State::ENABLED(), 'fooBar'),
             ]
         ), $container->get('nusje2000_feature_toggle.default_environment'));
 

--- a/tests/Unit/Http/Response/FeatureMapperTest.php
+++ b/tests/Unit/Http/Response/FeatureMapperTest.php
@@ -22,6 +22,10 @@ final class FeatureMapperTest extends TestCase
             new SimpleFeature('feature_1', State::DISABLED()),
             FeatureMapper::map(['name' => 'feature_1', 'enabled' => false])
         );
+        self::assertEquals(
+            new SimpleFeature('feature_1', State::ENABLED(), 'fooBar'),
+            FeatureMapper::map(['name' => 'feature_1', 'enabled' => true, 'description' => 'fooBar'])
+        );
     }
 
     public function testMapWithMissingName(): void
@@ -46,5 +50,11 @@ final class FeatureMapperTest extends TestCase
     {
         $this->expectExceptionObject(InvalidResponse::invalidKeyType('enabled', 'bool', 1));
         FeatureMapper::map(['name' => 'feature_1', 'enabled' => 1]);
+    }
+
+    public function testMapWithInvalidDescription(): void
+    {
+        $this->expectExceptionObject(InvalidResponse::invalidKeyType('description', 'string|null', []));
+        FeatureMapper::map(['name' => 'feature_1', 'enabled' => true, 'description' => []]);
     }
 }


### PR DESCRIPTION
## Warning! this PR is BC breaking due to changes to the Feature interface
Fixes #44 

### todo:
- [x] Add methods to the Feature interface
- [x] Add description to the Create and Update controllers
- [x] Make the View controller return the description
- [x] Add description to the FeatureMapper 
- [x] Allow  proposed config options to be succesfully parsed

Proposed config options:
```yaml
nusje2000_feature_toggle:
    environment:
        features:
            feature_toggle_1: true
            feature_toggle_2: false
            feature_toggle_3:
                description: 'For human. By human.'
                value: false
```